### PR TITLE
Make compatible with neo4j-migrations.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "commander": "^9.0.0",
+    "crc": "^4.1.0",
     "cypher-query-builder": "^6.0.4",
     "joi": "^17.6.0",
     "neo4j-driver-core": "^4.4.2"


### PR DESCRIPTION
This changes a couple of things and I can understand if you don't want this. Also, I haven't run the tests, I'm happy that I made npm and typescript work. I was able to migrate things with your tools and verify with mine and vice versa.
Key point here is using the same hashing as well as not using numeric version ids. 
Also, I fixed the date (should be a real date)
Also, I added the duration.

I think both of our projects would benefit if interoperable.
In mine, I would need to adapt to slightly different Cypher file names.
However, I do thing the "VID__name.cypher" has a well established tradition inside database refactoring.

If you don't want it as a whole, pick what you like :) 


- Allows for migrations having the naming V1_2_3__name.cypher
- Replaces „id“ with „version“ in the migration nodes
- Do a path matching instead of <= id
- Allows for arbitrary named verions
- Uses an actual date in the time of migrations
- records he migrations
- uses crc32 hashing of the files