### PR TITLE
fix: allow setting database config property from env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ MORPHEUS_USERNAME=neo4j
 # This refers to the password of the database.
 MORPHEUS_PASSWORD=neo4j
 
+# This refers to the name of the database.
+MORPHEUS_DATABASE=neo4j # default value
+
 # This refers to the path where the migrations are located.
 MORPHEUS_MIGRATIONS_PATH=neo4j/migrations # default value
 ```
@@ -141,6 +144,7 @@ import { MorpheusModule } from 'morpheus4j';
       port: 7687,
       username: 'neo4j',
       password: 'password',
+      database: 'neo4j',
       migrationsPath: './neo4j/migrations', // default value
     }),
     // Async register
@@ -152,6 +156,7 @@ import { MorpheusModule } from 'morpheus4j';
         port: configService.get('MORPHEUS_PORT'),
         username: configService.get('MORPHEUS_USERNAME'),
         password: configService.get('MORPHEUS_PASSWORD'),
+        database: configService.get('MORPHEUS_DATABASE'),
         migrationsPath: './neo4j/migrations', // default value
       }),
       inject: [ConfigService],

--- a/nestjs-example/src/app.module.ts
+++ b/nestjs-example/src/app.module.ts
@@ -33,6 +33,7 @@ import { MigrationsModule } from './migrations.module';
         port: configService.get('MORPHEUS_PORT'),
         username: configService.get('MORPHEUS_USERNAME'),
         password: configService.get('MORPHEUS_PASSWORD'),
+        database: configService.get('MORPHEUS_DATABASE'),
         migrationsPath: './neo4j/migrations', // default value
       }),
       inject: [ConfigService],

--- a/src/cli/fs.service.ts
+++ b/src/cli/fs.service.ts
@@ -91,6 +91,7 @@ export class FsService {
       password: 'neo4j',
       scheme: Neo4jScheme.NEO4J,
       migrationsPath: DEFAULT_MIGRATIONS_PATH,
+      database: 'neo4j',
     };
     writeFileSync(MORPHEUS_FILE_NAME, JSON.stringify(defaultConfig, null, 2));
     this.logger.log(`Morpheus file created: ${MORPHEUS_FILE_NAME}`);

--- a/src/config/config-loader.ts
+++ b/src/config/config-loader.ts
@@ -47,6 +47,7 @@ export class ConfigLoader {
       port: Number(process.env.MORPHEUS_PORT),
       username: process.env.MORPHEUS_USERNAME,
       password: process.env.MORPHEUS_PASSWORD,
+      database: process.env.MORPHEUS_DATABASE,
       migrationsPath: process.env.MORPHEUS_MIGRATIONS_PATH,
     };
     this.validateConfig(config);


### PR DESCRIPTION
Hey Mariano, I realised I forgot to allow setting the database property from the MORPHEUS_DATABASE env var.  This PR should fix that.