### PR TITLE
feat(migrate): add transaction-mode flag for improved migration control

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -1,9 +1,5 @@
-# This is a basic workflow that is manually triggered
-
 name: build-deploy
 
-# Controls when the action will run. Workflow runs when manually triggered using the UI
-# or API.
 on:
   push:
     branches:
@@ -12,19 +8,15 @@ on:
     branches:
       - master
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # Build and deploy all the components
   build-deploy:
     name: Build-and-Deploy
     runs-on: ubuntu-latest
 
     steps:
-      # Get deploy code
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          # This is important for semantic-release to have access to the full history
           fetch-depth: 0
 
       - name: Get npm cache
@@ -40,21 +32,23 @@ jobs:
         with:
           node-version: 'lts/*'
 
-      # Build using the custom script (sam build + custom builds)
-      - name: Build
-        shell: bash
+      - name: Install Dependencies
+        run: npm ci
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test:cov
+
+      - name: Generate oclif Artifacts
         run: |
-          npm ci
           npm run build
-
-      - name: Generate oclif artifacts
-        run: |
-          # Generate readme
-          npm run prepack
-
+          npx oclif manifest
+          npx oclif readme
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           git add README.md
@@ -73,10 +67,11 @@ jobs:
             ['master']
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: './coverage/lcov.info'
+

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,11 +1,9 @@
 {
-  "require": [
-    "ts-node/register"
-  ],
-  "watch-extensions": [
-    "ts"
-  ],
+  "require": ["ts-node/register"],
+  "watch-files": ["src/**/*.ts", "test/**/*.ts"],
+  "watch-extensions": ["ts"],
   "recursive": true,
   "reporter": "spec",
-  "timeout": 60000
+  "timeout": 60000,
+  "extension": ["ts"]
 }

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ npm install -g morpheus4j
 $ morpheus COMMAND
 running command...
 $ morpheus (--version)
-morpheus4j/4.1.0 linux-x64 node-v20.13.1
+morpheus4j/4.1.0 linux-x64 node-v20.16.0
 $ morpheus --help [COMMAND]
 USAGE
   $ morpheus COMMAND
@@ -177,7 +177,7 @@ Generate a new timestamped migration file with boilerplate code
 
 ```
 USAGE
-  $ morpheus create NAME [-c <value>] [-m <value>]
+  $ morpheus create NAME [--json] [-c <value>] [-m <value>]
 
 ARGUMENTS
   NAME  Name of the migration (will be prefixed with a semver number)
@@ -185,6 +185,9 @@ ARGUMENTS
 FLAGS
   -c, --configFile=<value>      Path to the morpheus file. ./morpheus.json by default
   -m, --migrationsPath=<value>  Migrations path. Env: 'MORPHEUS_MIGRATIONS_PATH'
+
+GLOBAL FLAGS
+  --json  Format output as json.
 
 DESCRIPTION
   Generate a new timestamped migration file with boilerplate code
@@ -270,18 +273,20 @@ Execute pending database migrations in sequential order
 ```
 USAGE
   $ morpheus migrate [--json] [--debug] [-c <value>] [-m <value>] [-h <value>] [-p <value>] [-s <value>] [-P
-    <value>] [-u <value>] [-d <value>] [--dry-run]
+    <value>] [-u <value>] [-d <value>] [--dry-run] [--transaction-mode PER_MIGRATION|PER_STATEMENT]
 
 FLAGS
-  -P, --password=<value>        Neo4j password. Env: 'MORPHEUS_PASSWORD'
-  -c, --configFile=<value>      Path to the morpheus file. ./morpheus.json by default
-  -d, --database=<value>        Neo4j database. Env: 'MORPHEUS_DATABASE'
-  -h, --host=<value>            Neo4j host. Env: 'MORPHEUS_HOST'
-  -m, --migrationsPath=<value>  Migrations path. Env: 'MORPHEUS_MIGRATIONS_PATH'
-  -p, --port=<value>            Neo4j port. Env: 'MORPHEUS_PORT'
-  -s, --scheme=<value>          Neo4j scheme. Env: 'MORPHEUS_SCHEME'
-  -u, --username=<value>        Neo4j username. Env: 'MORPHEUS_USERNAME'
-      --dry-run                 Perform a dry run - no changes will be made to the database
+  -P, --password=<value>           Neo4j password. Env: 'MORPHEUS_PASSWORD'
+  -c, --configFile=<value>         Path to the morpheus file. ./morpheus.json by default
+  -d, --database=<value>           Neo4j database. Env: 'MORPHEUS_DATABASE'
+  -h, --host=<value>               Neo4j host. Env: 'MORPHEUS_HOST'
+  -m, --migrationsPath=<value>     Migrations path. Env: 'MORPHEUS_MIGRATIONS_PATH'
+  -p, --port=<value>               Neo4j port. Env: 'MORPHEUS_PORT'
+  -s, --scheme=<value>             Neo4j scheme. Env: 'MORPHEUS_SCHEME'
+  -u, --username=<value>           Neo4j username. Env: 'MORPHEUS_USERNAME'
+      --dry-run                    Perform a dry run - no changes will be made to the database
+      --transaction-mode=<option>  [default: PER_MIGRATION] Transaction mode
+                                   <options: PER_MIGRATION|PER_STATEMENT>
 
 GLOBAL FLAGS
   --debug  Enable debug logging
@@ -296,6 +301,10 @@ EXAMPLES
   $ morpheus migrate -m ~/path/to/migrations
 
   $ morpheus migrate --config ./custom-config.json
+
+  $ morpheus migrate --dry-run
+
+  $ morpheus migrate --transaction-mode=PER_STATEMENT
 ```
 
 _See code: [src/commands/migrate.ts](https://github.com/marianozunino/morpheus/blob/v4.1.0/src/commands/migrate.ts)_

--- a/morpheus.json
+++ b/morpheus.json
@@ -2,8 +2,9 @@
   "database": "neo4j",
   "host": "localhost",
   "migrationsPath": "neo4j/migrations",
-  "password": "password",
+  "password": "neo4j",
   "port": 7687,
   "scheme": "neo4j",
+  "transactionMode": "PER_MIGRATION",
   "username": "neo4j"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,24 +27,26 @@
         "@nestjs/testing": "^10.0.0",
         "@oclif/prettier-config": "^0.2.1",
         "@oclif/test": "^4.0.0",
-        "@types/chai": "^4.0.0",
+        "@types/chai": "4.3.20",
         "@types/fs-extra": "^11.0.4",
-        "@types/mocha": "^10.0.0",
+        "@types/mocha": "10.0.9",
         "@types/node": "^18.0.0",
+        "@types/sinon": "17.0.3",
         "c8": "10.1.2",
-        "chai": "^4.0.0",
+        "chai": "4.5.0",
         "chance": "^1.1.12",
         "eslint": "^8.0.0",
         "eslint-config-oclif": "^5.0.0",
         "eslint-config-oclif-typescript": "^3.0.0",
         "eslint-config-prettier": "^9.0.0",
         "husky": "9.1.6",
-        "mocha": "^10.0.0",
+        "mocha": "10.8.2",
         "nodemon": "^3.1.7",
         "oclif": "^4.0.0",
         "shx": "^0.3.3",
+        "sinon": "19.0.2",
         "testcontainers": "^10.13.2",
-        "ts-node": "^10.0.0",
+        "ts-node": "10.9.2",
         "typescript": "^5.0.0"
       },
       "engines": {
@@ -1942,6 +1944,55 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/commons/node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.4.tgz",
+      "integrity": "sha512-wpUq+QiKxrWk7U2pdvNSY9fNX62/k+7eEdlQMO0A3rU8tQ+vvzY/WzBhMz+GbQlATXZlXWYQqFWNFcn1SVvThA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)"
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.6.tgz",
@@ -2854,6 +2905,23 @@
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7251,6 +7319,13 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7376,6 +7451,13 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7551,9 +7633,9 @@
       "license": "MIT"
     },
     "node_modules/mocha": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.3.tgz",
-      "integrity": "sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7664,6 +7746,30 @@
       "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-5.26.0.tgz",
       "integrity": "sha512-S3nHbqGuKPktWkRGenfx8Dt4MuqqrrUQjo4COhRj9r9P6WOjd0jzF/wyZb8H44pW5Qx/gmqn9B3If+7gfiaRmw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -9188,6 +9294,48 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sinon": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
+      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.2",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/slash": {

--- a/package.json
+++ b/package.json
@@ -31,24 +31,26 @@
     "@nestjs/testing": "^10.0.0",
     "@oclif/prettier-config": "^0.2.1",
     "@oclif/test": "^4.0.0",
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.20",
     "@types/fs-extra": "^11.0.4",
-    "@types/mocha": "^10.0.0",
+    "@types/mocha": "10.0.9",
     "@types/node": "^18.0.0",
+    "@types/sinon": "17.0.3",
     "c8": "10.1.2",
-    "chai": "^4.0.0",
+    "chai": "4.5.0",
     "chance": "^1.1.12",
     "eslint": "^8.0.0",
     "eslint-config-oclif": "^5.0.0",
     "eslint-config-oclif-typescript": "^3.0.0",
     "eslint-config-prettier": "^9.0.0",
     "husky": "9.1.6",
-    "mocha": "^10.0.0",
+    "mocha": "10.8.2",
     "nodemon": "^3.1.7",
     "oclif": "^4.0.0",
     "shx": "^0.3.3",
+    "sinon": "19.0.2",
     "testcontainers": "^10.13.2",
-    "ts-node": "^10.0.0",
+    "ts-node": "10.9.2",
     "typescript": "^5.0.0"
   },
   "engines": {
@@ -90,15 +92,16 @@
     "build": "shx rm -rf dist && tsc -b",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "postpack": "shx rm -f oclif.manifest.json",
     "prepack": "npm run build && oclif manifest && oclif readme",
-    "test": "c8 mocha \"test/**/*.test.ts\"",
+    "test:cov": "c8 mocha",
+    "test": "echo noop",
+    "postpack": "shx rm -f oclif.manifest.json",
     "version": "oclif readme && git add README.md",
     "watch": "nodemon --watch src --ext ts --exec \"npm run build\"",
     "prepare": "husky"
   },
   "main": "dist/nestjs/index.js",
-  "types": "dist/nesjs/index.d.ts",
+  "types": "dist/nestjs/index.d.ts",
   "c8": {
     "include": [
       "src/**/*.ts"
@@ -114,7 +117,7 @@
       "text",
       "lcov"
     ],
-    "cache": false,
+    "cache": true,
     "all": true
   },
   "packageManager": "npm@10.8.3+sha512.d08425c8062f56d43bb8e84315864218af2492eb769e1f1ca40740f44e85bd148969382d651660363942e5909cb7ffcbef7ca0ae963ddc2c57a51243b4da8f56"

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import {MORPHEUS_FILE_NAME} from '../constants'
 import {ConfigService} from '../services/config.service'
 import {CreateService} from '../services/create.service'
+import {Logger} from '../services/logger'
 import {ConfigFlags} from '../shared-flags'
 
 export default class Create extends Command {
@@ -16,6 +17,8 @@ export default class Create extends Command {
   }
 
   static override description = 'Generate a new timestamped migration file with boilerplate code'
+
+  static enableJsonFlag = true
 
   static override examples = [
     '<%= config.bin %> create add-user-nodes',
@@ -34,6 +37,8 @@ export default class Create extends Command {
 
   public async run(): Promise<void> {
     const {args, flags} = await this.parse(Create)
+
+    Logger.initialize(flags.json, flags.debug)
 
     try {
       const configFile = this.getConfigFile(flags.configFile)

--- a/src/services/create.service.ts
+++ b/src/services/create.service.ts
@@ -1,10 +1,10 @@
-import {ensureDir, pathExists, readdir, writeFile} from 'fs-extra'
+import {ensureDir, readdir, writeFile} from 'fs-extra'
 import path from 'node:path'
 import slugify from 'slugify'
 
 import {DEFAULT_MIGRATIONS_PATH, MIGRATION_NAME_REGEX, STARTING_VERSION, VALID_FILE_EXTENSIONS} from '../constants'
 import {MigrationError} from '../errors'
-import {MigrationOptions, Neo4jConfig} from '../types'
+import {Neo4jConfig} from '../types'
 import {Logger} from './logger'
 
 export class CreateService {
@@ -12,7 +12,7 @@ export class CreateService {
 
   constructor(private readonly config: Pick<Neo4jConfig, 'migrationsPath'>) {}
 
-  public async generateMigration(fileName: string, options: MigrationOptions = {}): Promise<void> {
+  public async generateMigration(fileName: string): Promise<void> {
     try {
       this.validateFileName(fileName)
 
@@ -25,7 +25,7 @@ export class CreateService {
       const fileNameWithPrefix = `V${newVersion}__${safeFileName}.cypher`
       const filePath = path.join(migrationsPath, fileNameWithPrefix)
 
-      await this.createMigrationFile(filePath, options.template ?? this.migrationTemplate, options.force)
+      await this.createMigrationFile(filePath, this.migrationTemplate)
       Logger.info(`Migration file created: ${filePath}`)
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error occurred'
@@ -40,11 +40,7 @@ export class CreateService {
     })
   }
 
-  private async createMigrationFile(filePath: string, content: string, force = false): Promise<void> {
-    if (!force && (await pathExists(filePath))) {
-      throw new MigrationError(`Migration file already exists: ${filePath}`)
-    }
-
+  private async createMigrationFile(filePath: string, content: string): Promise<void> {
     try {
       await writeFile(filePath, content.trim() + '\n')
     } catch (error) {

--- a/src/services/init.service.ts
+++ b/src/services/init.service.ts
@@ -2,7 +2,7 @@ import {ensureDirSync, existsSync, writeJSONSync} from 'fs-extra'
 import path from 'node:path'
 
 import {DEFAULT_MIGRATIONS_PATH} from '../constants'
-import {Neo4jConfig, Neo4jScheme} from '../types'
+import {Neo4jConfig, Neo4jScheme, TransactionMode} from '../types'
 
 export type InitOptions = {
   configFile: string
@@ -32,6 +32,7 @@ export class InitService {
       password: 'neo4j',
       port: 7687,
       scheme: Neo4jScheme.NEO4J,
+      transactionMode: TransactionMode.PER_MIGRATION,
       username: 'neo4j',
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,17 @@ export enum Neo4jScheme {
   NEO4J_SECURE_SELF_SIGNED = 'neo4j+ssc',
 }
 
+export enum TransactionMode {
+  /**
+   * Run all statements in one transaction. May need more memory, but it's generally safer. Either the migration runs as a whole or not at all.
+   */
+  PER_MIGRATION = 'PER_MIGRATION',
+  /**
+   * Runs each statement in a separate transaction. May leave your database in an inconsistent state when one statement fails.
+   */
+  PER_STATEMENT = 'PER_STATEMENT',
+}
+
 export const Neo4jConfigSchema = z.object({
   database: z.string().optional(),
   host: z.string().min(1),
@@ -17,6 +28,7 @@ export const Neo4jConfigSchema = z.object({
   password: z.string().min(1),
   port: z.number().int().positive(),
   scheme: z.nativeEnum(Neo4jScheme),
+  transactionMode: z.nativeEnum(TransactionMode).default(TransactionMode.PER_STATEMENT).optional(),
   username: z.string().min(1),
 })
 
@@ -32,8 +44,7 @@ export interface Neo4jMigrationNode {
 
 export interface MigrationOptions {
   dryRun?: boolean
-  force?: boolean
-  template?: string
+  transactionMode?: TransactionMode
 }
 
 export type MigrationInfo = {

--- a/test/commands/create.test.ts
+++ b/test/commands/create.test.ts
@@ -13,7 +13,7 @@ describe('create', () => {
   let commandResult: Awaited<ReturnType<typeof runCommand>>
 
   beforeEach(() => {
-    Logger.initialize() // Reset logger
+    Logger.initialize(false, false) // Reset logger
   })
 
   before(async () => {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -47,6 +47,16 @@ describe('init', () => {
     expect(fileContent).to.not.equal('existing content')
   })
 
+  it('created a morpheus file in the current directory if no -c flag is used', async () => {
+    // delete possibly existing morpheus file
+    fs.removeSync(path.join(process.cwd(), MORPHEUS_FILE_NAME))
+    const result = await runCommand(['init'])
+    commandResult = result
+    const stdout = result.stdout
+    expect(stdout).to.contain('Configuration file created ')
+    expect(fs.existsSync(path.join(process.cwd(), MORPHEUS_FILE_NAME))).to.be.true
+  })
+
   it('fails to create morpheus file if it exists and force is not used', async () => {
     const filePath = path.join(configDir, MORPHEUS_FILE_NAME)
     fs.ensureDirSync(path.dirname(filePath))

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,8 @@
+import {expect} from 'chai'
+import {run} from '../src'
+
+describe('run', () => {
+  it('should be defined', () => {
+    expect(run).to.not.be.undefined
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "target": "es2022",
     "esModuleInterop": true,
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
- Introduced a new `--transaction-mode` flag for the `migrate` command.
- This flag allows users to specify how migrations are executed, enabling options for running transactions per statement or per migration.