### PR TITLE
refactor(config): streamline default paths and remove redundant path imports

### DIFF
--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -1,7 +1,5 @@
 import {Command, Flags, Interfaces} from '@oclif/core'
-import path from 'node:path'
 
-import {DEFAULT_MIGRATIONS_PATH, MORPHEUS_FILE_NAME} from './constants'
 import {ConfigService} from './services/config.service'
 import {Logger} from './services/logger'
 import {AuthFlags, ConfigFlags, ConnectionFlags, DatabaseFlags} from './shared-flags'
@@ -42,26 +40,23 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
   }
 
   protected getConfig(): Neo4jConfig {
-    const configFile = this.getConfigFile()
-
     const config = ConfigService.load(
       {
         database: this.flags.database,
         host: this.flags.host,
-        migrationsPath: this.flags.migrationsPath ?? DEFAULT_MIGRATIONS_PATH,
+        migrationsPath: this.flags.migrationsPath,
         password: this.flags.password,
         port: this.flags.port,
         scheme: this.flags.scheme,
         username: this.flags.username,
       },
-      configFile,
+      this.getConfigFile(),
     )
     return config
   }
 
   protected getConfigFile(): string {
-    const configFile = this.flags.configFile ?? path.join(process.cwd(), MORPHEUS_FILE_NAME)
-    return configFile
+    return this.flags.configFile
   }
 
   public async init(): Promise<void> {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,7 +1,5 @@
 import {Args, Command} from '@oclif/core'
-import path from 'node:path'
 
-import {MORPHEUS_FILE_NAME} from '../constants'
 import {ConfigService} from '../services/config.service'
 import {CreateService} from '../services/create.service'
 import {Logger} from '../services/logger'
@@ -30,19 +28,13 @@ export default class Create extends Command {
     ...ConfigFlags,
   }
 
-  protected getConfigFile(configFileByArg?: string): string {
-    const configFile = configFileByArg ?? path.join(process.cwd(), MORPHEUS_FILE_NAME)
-    return configFile
-  }
-
   public async run(): Promise<void> {
     const {args, flags} = await this.parse(Create)
 
     Logger.initialize(flags.json, flags.debug)
 
     try {
-      const configFile = this.getConfigFile(flags.configFile)
-      const config = ConfigService.loadWithOutValidation(flags, configFile)
+      const config = ConfigService.loadWithOutValidation(flags, flags.configFile)
       await new CreateService(config).generateMigration(args.name)
     } catch (error) {
       this.error(error instanceof Error ? error.message : String(error))

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -18,7 +18,8 @@ export default class Init extends Command {
   static override flags = {
     configFile: Flags.string({
       char: 'c',
-      description: 'Path to the morpheus file. ./morpheus.json by default',
+      default: path.join(process.cwd(), MORPHEUS_FILE_NAME),
+      description: 'Path to the morpheus file (CWD/morpheus.json by default)',
     }),
     force: Flags.boolean({
       char: 'f',
@@ -35,14 +36,13 @@ export default class Init extends Command {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(Init)
-    const configFile = this.getConfigFile(flags.configFile)
 
     try {
       new InitService({
-        configFile,
+        configFile: flags.configFile,
         force: flags.force,
       }).createMorpheusFile()
-      Logger.info(`Configuration file created successfully: ${configFile}`)
+      Logger.info(`Configuration file created successfully: ${flags.configFile}`)
     } catch (error) {
       Logger.error((error as Error).message)
     }

--- a/src/shared-flags.ts
+++ b/src/shared-flags.ts
@@ -1,12 +1,14 @@
 import * as core from '@oclif/core'
+import path from 'node:path'
 
-import {EnvKeys} from './constants'
+import {DEFAULT_MIGRATIONS_PATH, EnvKeys, MORPHEUS_FILE_NAME} from './constants'
 
 // Method 1: Sort alphabetically
 const baseFlags: core.Interfaces.FlagInput = {
   configFile: core.Flags.string({
     char: 'c',
-    description: 'Path to the morpheus file. ./morpheus.json by default',
+    default: path.join(process.cwd(), MORPHEUS_FILE_NAME),
+    description: 'Path to the morpheus file (CWD/morpheus.json by default)',
   }),
   database: core.Flags.string({
     char: 'd',
@@ -20,6 +22,7 @@ const baseFlags: core.Interfaces.FlagInput = {
   }),
   migrationsPath: core.Flags.string({
     char: 'm',
+    default: DEFAULT_MIGRATIONS_PATH,
     description: `Migrations path. Env: '${EnvKeys.MIGRATIONS_PATH}'`,
     env: EnvKeys.MIGRATIONS_PATH,
     required: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 import {DateTime, Duration} from 'neo4j-driver'
 import {z} from 'zod'
 
+import {DEFAULT_MIGRATIONS_PATH} from './constants'
+
 export enum Neo4jScheme {
   BOLT = 'bolt',
   BOLT_SECURE = 'bolt+s',
@@ -24,7 +26,7 @@ export enum TransactionMode {
 export const Neo4jConfigSchema = z.object({
   database: z.string().optional(),
   host: z.string().min(1),
-  migrationsPath: z.string().optional(),
+  migrationsPath: z.string().default(DEFAULT_MIGRATIONS_PATH).optional(),
   password: z.string().min(1),
   port: z.number().int().positive(),
   scheme: z.nativeEnum(Neo4jScheme),


### PR DESCRIPTION
- Remove redundant `path` import across multiple files where `MORPHEUS_FILE_NAME` and `DEFAULT_MIGRATIONS_PATH` constants are used directly.
- Simplify `getConfigFile` method in `BaseCommand` and `Create` commands by using `flags.configFile` directly.
- Set default value for `configFile` and `migrationsPath` in shared flags and schema to centralize path defaults, ensuring consistent use of `MORPHEUS_FILE_NAME` and `DEFAULT_MIGRATIONS_PATH`.
- Update `Neo4jConfigSchema` to default `migrationsPath` to `DEFAULT_MIGRATIONS_PATH`, improving config initialization flexibility.